### PR TITLE
Fix bin execution example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn global add anki-to-json
 
 ## Bin
 ```sh
-ankiToJson jp_core_2000_1.apkg
+ankiToJson jp_core_2000_1.apkg output_directory
 ```
 
 ## NodeJS


### PR DESCRIPTION
This PR adds output directory as a second parameter to the bin execution example. Without that parameter, the scripts fails to execute and causes the issue reported in #6.